### PR TITLE
Add JWT to Session and changing some wording to be more clear

### DIFF
--- a/django_montage/urls.py
+++ b/django_montage/urls.py
@@ -22,6 +22,6 @@ urlpatterns = [
     url(r'^viewer/(?P<match>.*)/$', views.viewer),
     url(r'^project/[(?P<match>.*)/]?$', views.project),
     url(r'^admin/', admin.site.urls),
+    url(r'^user/', include('registration.backends.admin_approval.urls')),
     url(r'^user/', include('rafter_user_service.urls')),
-    url(r'^accounts/', include('registration.backends.admin_approval.urls')),
 ]

--- a/rafter_user_service/apps.py
+++ b/rafter_user_service/apps.py
@@ -3,3 +3,6 @@ from django.apps import AppConfig
 
 class RafterUserServiceConfig(AppConfig):
     name = 'rafter_user_service'
+    
+    def ready(self):
+        from . import signals

--- a/rafter_user_service/models.py
+++ b/rafter_user_service/models.py
@@ -48,6 +48,10 @@ class Profile(models.Model):
     def save_user_profile(sender, instance, **kwargs):
         instance.profile.save()
         
+    def generate_token(self):
+        payload = jwt_payload_handler(self.user)
+        return jwt_encode_handler(payload)
+        
     def __str__(self):
         return self.user.username
 
@@ -68,7 +72,7 @@ class Application(models.Model):
     def user(self, value):
         self.profile = value.profile
 
-    def generate_access_token(self):
+    def generate_secret(self):
         charset = string.ascii_uppercase + string.digits + string.ascii_lowercase
         token = ''.join(random.choices(charset, k=30))
 
@@ -79,12 +83,8 @@ class Application(models.Model):
         # Return the unhashed token
         return token
 
-    def check_token(self, token):
+    def check_secret(self, token):
         return self.access_token and bcrypt.hashpw(token.encode('utf-8'), self.access_token) == self.access_token
-
-    def get_user_token(self):
-        payload = jwt_payload_handler(self.user)
-        return jwt_encode_handler(payload)
 
     def __str__(self):
         return self.name

--- a/rafter_user_service/serializers.py
+++ b/rafter_user_service/serializers.py
@@ -10,12 +10,12 @@ class ApplicationJWTSerializer(serializers.Serializer):
     def validate(self, data):
         app = self.context['app']
         
-        if not app.check_token(data['secret']):
+        if not app.check_secret(data['secret']):
             msg = 'Wrong application secret.'
             raise serializers.ValidationError(msg)
 
         return {
-            'token': app.get_user_token()
+            'token': app.profile.generate_token()
         }
 
 class ApplicationSerializer(serializers.ModelSerializer):

--- a/rafter_user_service/signals.py
+++ b/rafter_user_service/signals.py
@@ -1,0 +1,7 @@
+from django.contrib.auth.signals import user_logged_in
+from django.dispatch import receiver
+
+@receiver(user_logged_in)
+def add_jwt(sender, user, request, **kwargs):
+    token = user.profile.generate_token()
+    request.session['JWT'] = token

--- a/rafter_user_service/test/test_models.py
+++ b/rafter_user_service/test/test_models.py
@@ -40,8 +40,8 @@ class ApplicationTest(TestCase):
 
     def test_generate_access_token(self):
         app = make_app(self.user, 'test')
-        token = app.generate_access_token()
+        token = app.generate_secret()
 
         self.assertIsNotNone(app.access_token)
         self.assertNotEqual(len(app.access_token), 0)
-        self.assertTrue(app.check_token(token))
+        self.assertTrue(app.check_secret(token))

--- a/rafter_user_service/test/test_signals.py
+++ b/rafter_user_service/test/test_signals.py
@@ -1,0 +1,17 @@
+from django.test import TestCase
+from django.http.request import HttpRequest
+from django.contrib.auth.models import User
+from django.contrib.auth.signals import user_logged_in
+from django.conf import settings
+from importlib import import_module
+from .util import make_test_user
+
+class AddJWTTest(TestCase):
+    
+    def test_add_jwt(self):
+        user = make_test_user()
+        request = HttpRequest()
+        engine = import_module(settings.SESSION_ENGINE)
+        request.session = engine.SessionStore(None)
+        user_logged_in.send(sender=user.__class__, request=request, user=user)
+        self.assertIn('JWT', request.session)

--- a/rafter_user_service/test/test_views.py
+++ b/rafter_user_service/test/test_views.py
@@ -123,13 +123,13 @@ class ApplicationGetSecretTest(TestCase):
         self.assertEqual(response.status_code, 200)
         secret_json = response.json()
         self.assertEqual(secret_json['app_id'], str(app.pk))
-        self.assertTrue(app.check_token(secret_json['app_secret']))
+        self.assertTrue(app.check_secret(secret_json['app_secret']))
 
 class ApplicationAuthenticateTest(TestCase):
     def setUp(self):
         self.user = make_test_user()
         self.app = make_app(self.user, 'test')
-        self.secret = self.app.generate_access_token()
+        self.secret = self.app.profile.generate_token()
 
     def get_auth(self, pk):
         return self.client.get(reverse('user:auth_app', args=[pk]))

--- a/rafter_user_service/urls.py
+++ b/rafter_user_service/urls.py
@@ -12,5 +12,5 @@ urlpatterns = [
     url(r'^applications/(?P<pk>[0-9]+)/secret/$', get_token, name='secret'),
     url(r'^authenticate/(?P<pk>[0-9]+)/$', authenticate_app, name='auth_app'),
     url(r'^public_key/$', get_public_key, name='pub_key'),
-    url(r'^(?P<username>.+)/$', UserDetail.as_view(), name='user'),
+    url(r'^profile/(?P<username>.+)/$', UserDetail.as_view(), name='user'),
 ]

--- a/rafter_user_service/views.py
+++ b/rafter_user_service/views.py
@@ -11,7 +11,6 @@ from rest_framework.permissions import IsAuthenticated
 from rafter_user_service.models import Application, Profile
 from rafter_user_service.serializers import ApplicationJWTSerializer, ApplicationSerializer
 from rafter_user_service.permissions import IsOwnerOrPost
-from django.contrib.auth.views import LoginView as Login
 from django.contrib.auth.models import User
 from django.contrib.auth.decorators import login_required
 
@@ -100,15 +99,3 @@ def get_public_key(request):
         return Response(data)
     
     raise Http404('No public key.')
-
-class LoginView(Login):
-    """
-    Extending the login view so that we can add the JWT to the session.
-    Note that we add the JWT to the session after the login signal has been
-    sent.
-    """
-    def form_valid(self, form):
-        auth_login(self.request, form.get_user())
-        token = self.request.user.profile.generate_token()
-        self.request.session['JWT'] = token
-        return HttpResponseRedirect(self.get_success_url())


### PR DESCRIPTION
Adding the JWT to the Session is pretty straightforward

I also changed some things like `Application.generate_user_token` -> `Profile.generate_token` and `Application.generate_access_token()` -> `Application.generate_secret()` to keep JWT and app secrets separate.  

This should really be two pull requests, but they got bundled in to my develop branch on my fork.